### PR TITLE
fix: kart branch builds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,15 @@ jobs:
         with: 
           fetch-depth: 0
 
+      - name: Setup GIT version
+        id: version
+        run: |
+          GIT_VERSION=$(git describe --tags --always --match 'v*')
+          GIT_VERSION_MAJOR=$(echo "$GIT_VERSION" | cut -d. -f1)
+          GIT_VERSION_MAJOR_MINOR=$(echo "$GIT_VERSION" | cut -d. -f1,2)
+
+          { echo "version=${GIT_VERSION}"; echo "version_major=${GIT_VERSION_MAJOR}"; echo "version_major_minor=${GIT_VERSION_MAJOR_MINOR}"; } >> "$GITHUB_OUTPUT"
+
       # Only build containers on branches otherwise container builds are duplicated deploy-nonprod-containers
       - name: Set up Docker Buildx
         if: ${{ github.ref != 'refs/heads/master' }}
@@ -22,6 +31,7 @@ jobs:
           push: false
           build-args: |
             GIT_HASH=${{ github.sha }}
+            GIT_VERSION=${{ steps.version.outputs.version }} 
             GITHUB_RUN_ID=${{ github.run_id}}
 
   deploy-container:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           fetch-depth: 0
 
       - name: Setup GIT version
@@ -37,7 +37,8 @@ jobs:
   deploy-container:
     runs-on: ubuntu-latest
     concurrency: deploy-dev-${{ github.ref }}
-    needs: ["build"]
+    needs:
+      ["build"]
       # On push to master when it is not a release!
     if: ${{ github.ref == 'refs/heads/master' && !startsWith(github.event.head_commit.message, 'release:') }}
 
@@ -51,7 +52,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           fetch-depth: 0
 
       - name: Setup GIT version

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with: 
+        with:
           fetch-depth: 0
 
       - name: Setup GIT version


### PR DESCRIPTION
### Motivation

`kart --version` is failing on branches due to weird encoding of `$GIT_VERSION`

### Modifications

Add the missing GIT_VERSION when bulding off a branch

### Verification

This pull request will test the build
