### PR TITLE
fix: disable kart helper until zero length env vars are fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG GIT_HASH=unknown
 ENV GIT_HASH=${GIT_HASH}
 
 ARG KART_VERSION=0.17.0
+# Disable kart helper until https://github.com/koordinates/kart/issues/1085 is resolved
+ENV KART_USE_HELPER=0
 
 COPY --from=uv_source /uv /uvx /bin/
 


### PR DESCRIPTION
### Motivation

kart helper is triggering errors with empty environment variables

### Modifications

Disable the kart_helper for the container

### Verification

<!-- TODO: Say how you tested your changes. -->
