### PR TITLE
feat: bump gdal version to 3.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG UV_VERSION=0.9.16
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_source
 
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.12.0
+FROM ghcr.io/osgeo/gdal:ubuntu-full-3.12.2
 
 ARG GIT_VERSION
 ENV GIT_VERSION=${GIT_VERSION}


### PR DESCRIPTION
### Motivation

Bump version so we can use COVERING_BBOX_NAME=bbox from https://github.com/OSGeo/gdal/pull/13371

Currently parquet files end up with `geom_bbox`

### Modifications

bump version

### Verification


