### PR TITLE
feat: use gdal 3.13.0dev BM-1567

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG UV_VERSION=0.9.16
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_source
 
-FROM ghcr.io/osgeo/gdal:ubuntu-full-3.12.2
+FROM ghcr.io/osgeo/gdal:ubuntu-full-latest@sha256:ec307f0371879ab07ec517a8bd28457522c13ed8ef7b7e78e47d2ea82e2ea563
 
 ARG GIT_VERSION
 ENV GIT_VERSION=${GIT_VERSION}


### PR DESCRIPTION
### Motivation

Our to-parquet workflow is currently broken because GDAL 3.12.2 does not support `COVERING_BBOX_NAME`

### Modifications

Use latest 3.13.0dev version (not yet tagged) of base image until a 3.13 release is available.
Image tagged with SHA.

### Verification

`gdal --version` matches and build works.
